### PR TITLE
chore: re-establish luajit source as submodule

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Submodules
-        run: git submodule update --init deps/vcpkg
+        run: |
+          git submodule update --init deps/luajit
+          git submodule update --init deps/vcpkg
 
       - uses: lukka/get-cmake@latest
 
@@ -54,7 +56,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Submodules
-        run: git submodule update --init deps/vcpkg
+        run: |
+          git submodule update --init deps/luajit
+          git submodule update --init deps/vcpkg
 
       - uses: lukka/get-cmake@latest
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/vcpkg"]
 	path = deps/vcpkg
 	url = https://github.com/microsoft/vcpkg
+[submodule "deps/luajit"]
+	path = deps/luajit
+	url = https://github.com/WohlSoft/LuaJIT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(metsi)
 set(CMAKE_CXX_STANDARD 20)
 
 set(METSI_SIMLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/metsi-simlib/include)
-
+set(LUAJIT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/deps/luajit/src)
+add_subdirectory(deps/luajit EXCLUDE_FROM_ALL)
 add_subdirectory(metsi-app)
 add_subdirectory(metsi-simlib)

--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ The following subsections describe the main concepts for working with this proje
 
 ### Dependencies
 
-Dependencies are managed by vcpkg as a submodule.
-Initialize vcpkg by running
+LuaJIT dependency is included as a submodule.
+The csv-parser dependency is included as a single header source file in-project.
+Other dependencies are managed by vcpkg as a submodule.
+Initialize by running
 
 ```
+git submodule update --init deps/luajit
 git submodule update --init deps/vcpkg
 ./deps/vcpkg/bootstrap-vcpkg.bat # on Windows CMD or PowerShell
 ./deps/vcpkg/bootstrap-vcpkg.sh  # on Linux/OSX shells or Windows Git BASH shell
 ```
 
-This process essentially downloads `vcpkg.exe` on Windows or `vcpkg` on Linux or OSX, building it if necessary.
+This initializes the luajit submodule dependency.
+For vcpkg it essentially downloads `vcpkg.exe` on Windows or `vcpkg` on Linux or OSX, building it if necessary.
 For Windows, you can also manually obtain vcpkg.exe from https://github.com/microsoft/vcpkg-tool/releases/download/2023-03-01/vcpkg.exe and insert it into the `deps/vcpkg` directory.
 
 Resolving and installing dependency libraries should be performed automatically by CMake configuration (see below).
@@ -45,7 +49,7 @@ Table of dependency libraries:
 | yaml-cpp   | 0.7.0   | https://github.com/jbeder/yaml-cpp          | MIT     ||
 | csv-parser | 2.1.3   | https://github.com/vincentlaucsb/csv-parser | MIT     | Included as single header copy `src/metsi-app/src/csv_parser.hpp |
 | boost      | 0.81.0  | https://github.com/boostorg/boost           | BSL-1.0 | boost-test, boost-program-options, boost-lexical-cast            |
-| luajit     | 2.1     | https://github.com/LuaJIT/LuaJIT            | MIT     ||
+| luajit     | 2.1     | https://github.com/WohlSoft/LuaJIT          | MIT     | A fork of actual luajit repo, adding CMake build possibility     |
 
 ### CMake Presets
 
@@ -121,6 +125,6 @@ A default example run would be
 On Windows, you need to obtain Visual Studio 2022 (at least Community Edition).
 This will require Administrator privileges on your host.
 Use the Visual Studio Installer to obtain the MSVC CLI tools along with the version 17 MSVC toolchain.
-With this setup, the `msbuild-vcpkg` preset should work out of the box on any IDE or otherwise.
-It should be possible to use MinGW or other configurations, but this has not been explored.
+With this setup, the `msbuild-*` presets should work out of the box on any IDE or otherwise.
+It should be possible to use MinGW or other configurations with the `ninja-*` presets, but this has not been explored.
 

--- a/metsi-app/CMakeLists.txt
+++ b/metsi-app/CMakeLists.txt
@@ -1,15 +1,14 @@
 cmake_minimum_required(VERSION 3.2)
 project(metsi-app)
 
-#find_package(PkgConfig REQUIRED)
 find_package(Boost 1.81.0 COMPONENTS program_options REQUIRED)
 find_package(yaml-cpp 0.7.0 REQUIRED)
-#pkg_check_modules(LuaJIT REQUIRED luajit)
 include_directories(${Boost_INCLUDE_DIR})
+include_directories(${LUAJIT_INCLUDE_DIR})
 
 set(LIB_SOURCE_FILES src/sim_configuration.cpp src/file_io.cpp src/state_model.cpp src/app_io.cpp src/sim_events.cpp)
 set(SOURCE_FILES src/main.cpp ${LIB_SOURCE_FILES})
-set(METSI_EXTERNAL_DEPS yaml-cpp metsi-simlib ${Boost_LIBRARIES})
+set(METSI_EXTERNAL_DEPS yaml-cpp metsi-simlib libluajit ${Boost_LIBRARIES})
 set(METSI_ALL_DEPS metsi-applib ${METSI_EXTERNAL_DEPS})
 
 # metsi files are librarized for Boost unit testability
@@ -32,7 +31,7 @@ include_directories(${METSI_SIMLIB_INCLUDE_DIR})
 
 add_boost_test(tests/csv_parser_test.cpp ${METSI_ALL_DEPS})
 add_boost_test(tests/overlaid_object_test.cpp ${METSI_ALL_DEPS})
-#add_boost_test(tests/lua_test.cpp luajit-5.1 ${METSI_ALL_DEPS})
+add_boost_test(tests/lua_test.cpp ${METSI_ALL_DEPS})
 add_boost_test(tests/app_io_test.cpp ${METSI_ALL_DEPS})
 add_boost_test(tests/yaml_cpp_test.cpp ${METSI_ALL_DEPS})
 add_boost_test(tests/sim_configuration_test.cpp ${METSI_ALL_DEPS})

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "name": "metsi",
   "version": "1.0.0",
-  "dependencies": [ "boost-test", "boost-program-options", "boost-lexical-cast", "luajit", "yaml-cpp" ]
+  "dependencies": [ "boost-test", "boost-program-options", "boost-lexical-cast", "yaml-cpp" ]
 }


### PR DESCRIPTION
A fork of actual luajit. This adds CMake capabilities to the project and makes it trivially includeable.